### PR TITLE
add availability for multiple certs on one route, add tlssecret_refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,8 +355,13 @@ Routes use spec fields to reference listeners and TLS certificates:
 spec:
   listener_refs:
     - "https"              # Attach route to this listener
-  tlssecret_ref: "my-cert" # TLS certificate name (optional)
+  tlssecret_ref: "my-cert" # Primary TLS certificate (optional TLSSecret CR name)
+  tlssecret_refs:
+    - extra-cert-1         # Additional TLSSecret CR names (optional)
+    - extra-cert-2
 ```
+
+`tlssecret_refs` lists extra TLSSecret CRs whose certificates are merged into the same downstream TLS context as `tlssecret_ref`. If both are set, `tlssecret_ref` is listed first, then `tlssecret_refs`, with duplicates and blank entries dropped. Use this when one route needs multiple SDS-backed certs (for example multi-SNI setups). You can use `tlssecret_refs` alone without `tlssecret_ref`.
 
 ## Prometheus Metrics
 

--- a/config/crd/bases/envoyxds.io_routes.yaml
+++ b/config/crd/bases/envoyxds.io_routes.yaml
@@ -4778,6 +4778,13 @@ spec:
                   TLSSecretRef specifies the TLS secret to use for this route.
                   References a TLSSecret CR by name.
                 type: string
+              tlssecret_refs:
+                description: |-
+                  TLSSecretRefs specifies the TLS secrets to use for this route.
+                  References TLSSecret CRs by name.
+                items:
+                  type: string
+                type: array
               tracing:
                 description: HttpConnectionManager_Tracing represents the Envoy HttpConnectionManager_Tracing
                   configuration.

--- a/controllers/lds/README.md
+++ b/controllers/lds/README.md
@@ -170,12 +170,12 @@ By setting `spec.tlssecret_ref` to the name of a TLSSecret CR, the control plane
 Use `spec.tlssecret_refs` when the same route’s filter chain should load more than one TLS certificate via SDS—for example, multiple `TlsCertificateSdsSecretConfigs` for SNI or additional keypairs.
 
 By setting `spec.tlssecret_ref` or `spec.tlssecret_refs` in the Route configuration, the xDS control-plane ensures automatic application of the corresponding SDS secret to the `filter_chain.transport_socket` of the desired listener. This allows for secure communication between Envoy proxies and backend services by automatically injecting the required secrets.
- - You can set **only** `tlssecret_refs`, **only** `tlssecret_ref`, or **both**.
- - When both are set, `tlssecret_ref` is applied **first**, then each entry in `tlssecret_refs` in list order.
- - Duplicate secret names (between the two fields or inside `tlssecret_refs`) are removed. Empty strings are skipped; surrounding whitespace on names is trimmed.
 
-This automatic configuration simplifies the management of secrets within the LDS and eliminates manual intervention when 
-associating secrets with the transport socket of listeners. Each name must match the `metadata.name` of an existing TLSSecret CR.
+- You can set **only** `tlssecret_refs`, **only** `tlssecret_ref`, or **both**.
+- When both are set, `tlssecret_ref` is applied **first**, then each entry in `tlssecret_refs` in list order.
+- Duplicate secret names (between the two fields or inside `tlssecret_refs`) are removed. Empty strings are skipped; surrounding whitespace on names is trimmed.
+
+This automatic configuration simplifies the management of secrets within the LDS and eliminates manual intervention when associating secrets with the transport socket of listeners. Each name must match the `metadata.name` of an existing TLSSecret CR.
 
 This automatic configuration simplifies secret management on the listener and avoids hand-editing transport sockets for TLS.
 

--- a/controllers/lds/README.md
+++ b/controllers/lds/README.md
@@ -159,11 +159,26 @@ This automatic filter chain configuration simplifies the management of filter ch
 
 ## Automatic SDS Secret Configuration
 
-In the LDS, the Secret Discovery Service (SDS) secrets can be automatically applied to the `filter_chain.transport_socket` when you set the `tlssecret_ref` field in the Route spec using the name of the desired TLSSecret CR.
+In the LDS, the Secret Discovery Service (SDS) secrets can be automatically applied to the `filter_chain.transport_socket` when you reference TLSSecret CRs from the Route spec using the name of the desired TLSSecret CR.
 
-By setting `spec.tlssecret_ref` in the Route configuration, the xDS control-plane ensures automatic application of the corresponding SDS secret to the `filter_chain.transport_socket` of the desired listener. This allows for secure communication between Envoy proxies and backend services by automatically injecting the required secrets.
+### `tlssecret_ref` (single secret)
 
-This automatic configuration simplifies the management of secrets within the LDS and eliminates manual intervention when associating secrets with the transport socket of listeners.
+By setting `spec.tlssecret_ref` to the name of a TLSSecret CR, the control plane attaches that SDS secret to the route’s filter chain transport socket on the listener.
+
+### `tlssecret_refs` (multiple secrets)
+
+Use `spec.tlssecret_refs` when the same route’s filter chain should load more than one TLS certificate via SDS—for example, multiple `TlsCertificateSdsSecretConfigs` for SNI or additional keypairs.
+
+By setting `spec.tlssecret_ref` or `spec.tlssecret_refs` in the Route configuration, the xDS control-plane ensures automatic application of the corresponding SDS secret to the `filter_chain.transport_socket` of the desired listener. This allows for secure communication between Envoy proxies and backend services by automatically injecting the required secrets.
+- You can set **only** `tlssecret_refs`, **only** `tlssecret_ref`, or **both**.
+- When both are set, `tlssecret_ref` is applied **first**, then each entry in `tlssecret_refs` in list order.
+- Duplicate secret names (between the two fields or inside `tlssecret_refs`) are removed. Empty strings are skipped; surrounding whitespace on names is trimmed.
+
+This automatic configuration simplifies the management of secrets within the LDS and eliminates manual intervention when 
+associating secrets with the transport socket of listeners.
+Each name must match the `metadata.name` of an existing TLSSecret CR.
+
+This automatic configuration simplifies secret management on the listener and avoids hand-editing transport sockets for TLS.
 
 Please note that the `tlssecret_ref` field in the Route spec should match the name of the desired TLSSecret CR.
 

--- a/controllers/lds/README.md
+++ b/controllers/lds/README.md
@@ -180,7 +180,7 @@ Each name must match the `metadata.name` of an existing TLSSecret CR.
 
 This automatic configuration simplifies secret management on the listener and avoids hand-editing transport sockets for TLS.
 
-Please note that the `tlssecret_ref` field in the Route spec should match the name of the desired TLSSecret CR.
+Please note that the `tlssecret_ref` and `tlssecret_refs` fields in the Route spec should match the name of the desired TLSSecret CR.
 
 ## Annotations and Parameters
 

--- a/controllers/lds/README.md
+++ b/controllers/lds/README.md
@@ -170,13 +170,12 @@ By setting `spec.tlssecret_ref` to the name of a TLSSecret CR, the control plane
 Use `spec.tlssecret_refs` when the same route’s filter chain should load more than one TLS certificate via SDS—for example, multiple `TlsCertificateSdsSecretConfigs` for SNI or additional keypairs.
 
 By setting `spec.tlssecret_ref` or `spec.tlssecret_refs` in the Route configuration, the xDS control-plane ensures automatic application of the corresponding SDS secret to the `filter_chain.transport_socket` of the desired listener. This allows for secure communication between Envoy proxies and backend services by automatically injecting the required secrets.
-- You can set **only** `tlssecret_refs`, **only** `tlssecret_ref`, or **both**.
-- When both are set, `tlssecret_ref` is applied **first**, then each entry in `tlssecret_refs` in list order.
-- Duplicate secret names (between the two fields or inside `tlssecret_refs`) are removed. Empty strings are skipped; surrounding whitespace on names is trimmed.
+ - You can set **only** `tlssecret_refs`, **only** `tlssecret_ref`, or **both**.
+ - When both are set, `tlssecret_ref` is applied **first**, then each entry in `tlssecret_refs` in list order.
+ - Duplicate secret names (between the two fields or inside `tlssecret_refs`) are removed. Empty strings are skipped; surrounding whitespace on names is trimmed.
 
 This automatic configuration simplifies the management of secrets within the LDS and eliminates manual intervention when 
-associating secrets with the transport socket of listeners.
-Each name must match the `metadata.name` of an existing TLSSecret CR.
+associating secrets with the transport socket of listeners. Each name must match the `metadata.name` of an existing TLSSecret CR.
 
 This automatic configuration simplifies secret management on the listener and avoids hand-editing transport sockets for TLS.
 

--- a/controllers/lds/listener_controller.go
+++ b/controllers/lds/listener_controller.go
@@ -794,6 +794,7 @@ func prepareFilters(route envoyxdsv1alpha1.Route, lds *listenerv3.Listener) ([]*
 	delete(data, "filter_chain_match") // Used for filter chain matching
 	delete(data, "listener_refs")      // Custom field for route-to-listener binding
 	delete(data, "tlssecret_ref")      // Custom field for TLS secret binding
+	delete(data, "tlssecret_refs")     // Custom field for TLS secret binding (multiple)
 
 	// Re-marshal the map into JSON
 	routeData, err = json.Marshal(data)
@@ -899,9 +900,44 @@ func duplicateFound(lds *listenerv3.Listener, route *envoyxdsv1alpha1.Route, rou
 	return false
 }
 
+// routeTLSSecretNames returns TLSSecret CR names for the route filter chain transport socket.
+// tlssecret_ref (if set) is listed first, then tlssecret_refs, with duplicates removed.
+func routeTLSSecretNames(route *envoyxdsv1alpha1.Route) []string {
+	if route == nil {
+		return nil
+	}
+	var names []string
+	seen := make(map[string]struct{})
+	add := func(s string) {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			return
+		}
+		if _, ok := seen[s]; ok {
+			return
+		}
+		seen[s] = struct{}{}
+		names = append(names, s)
+	}
+	add(route.Spec.TLSSecretRef)
+	for _, ref := range route.Spec.TLSSecretRefs {
+		add(ref)
+	}
+	return names
+}
+
 func prepareSecretContext(route *envoyxdsv1alpha1.Route, lds *listenerv3.Listener, filter *listenerv3.FilterChain) *listenerv3.FilterChain {
-	if route.Spec.TLSSecretRef == "" {
+	secretNames := routeTLSSecretNames(route)
+	if len(secretNames) == 0 {
 		return filter
+	}
+
+	sdsConfigs := make([]*authv3.SdsSecretConfig, 0, len(secretNames))
+	for _, name := range secretNames {
+		sdsConfigs = append(sdsConfigs, &authv3.SdsSecretConfig{
+			Name:      name,
+			SdsConfig: configSource(),
+		})
 	}
 
 	isQuic := lds.UdpListenerConfig != nil &&
@@ -913,10 +949,7 @@ func prepareSecretContext(route *envoyxdsv1alpha1.Route, lds *listenerv3.Listene
 		quicTransport := &quicv3.QuicDownstreamTransport{
 			DownstreamTlsContext: &authv3.DownstreamTlsContext{
 				CommonTlsContext: &authv3.CommonTlsContext{
-					TlsCertificateSdsSecretConfigs: []*authv3.SdsSecretConfig{{
-						Name:      route.Spec.TLSSecretRef,
-						SdsConfig: configSource(),
-					}},
+					TlsCertificateSdsSecretConfigs: sdsConfigs,
 				},
 			},
 		}
@@ -934,10 +967,7 @@ func prepareSecretContext(route *envoyxdsv1alpha1.Route, lds *listenerv3.Listene
 		// Setup regular TLS transport socket
 		tlsc := &authv3.DownstreamTlsContext{
 			CommonTlsContext: &authv3.CommonTlsContext{
-				TlsCertificateSdsSecretConfigs: []*authv3.SdsSecretConfig{{
-					Name:      route.Spec.TLSSecretRef,
-					SdsConfig: configSource(),
-				}},
+				TlsCertificateSdsSecretConfigs: sdsConfigs,
 			},
 		}
 		if filter.FilterChainMatch != nil && filter.FilterChainMatch.ApplicationProtocols != nil {

--- a/controllers/lds/listener_controller_test.go
+++ b/controllers/lds/listener_controller_test.go
@@ -97,6 +97,32 @@ func TestConfigSource(t *testing.T) {
 	assert.NotNil(t, result.GetAds())
 }
 
+func TestRouteTLSSecretNames(t *testing.T) {
+	t.Run("nil route", func(t *testing.T) {
+		assert.Nil(t, routeTLSSecretNames(nil))
+	})
+	t.Run("no secrets", func(t *testing.T) {
+		r := &envoyxdsv1alpha1.Route{}
+		assert.Nil(t, routeTLSSecretNames(r))
+	})
+	t.Run("tlssecret_ref only", func(t *testing.T) {
+		r := &envoyxdsv1alpha1.Route{}
+		r.Spec.TLSSecretRef = "primary"
+		assert.Equal(t, []string{"primary"}, routeTLSSecretNames(r))
+	})
+	t.Run("tlssecret_refs only", func(t *testing.T) {
+		r := &envoyxdsv1alpha1.Route{}
+		r.Spec.TLSSecretRefs = []string{"s1", "s2"}
+		assert.Equal(t, []string{"s1", "s2"}, routeTLSSecretNames(r))
+	})
+	t.Run("ref plus refs dedupes trims skips empty", func(t *testing.T) {
+		r := &envoyxdsv1alpha1.Route{}
+		r.Spec.TLSSecretRef = "a"
+		r.Spec.TLSSecretRefs = []string{"  b ", "a", ""}
+		assert.Equal(t, []string{"a", "b"}, routeTLSSecretNames(r))
+	})
+}
+
 func TestListenerStatusEqual(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/pkg/xds/types/route/route.go
+++ b/pkg/xds/types/route/route.go
@@ -36,6 +36,10 @@ type Route struct {
 	// References a TLSSecret CR by name.
 	TLSSecretRef string `json:"tlssecret_ref,omitempty"`
 
+	// TLSSecretRefs specifies the TLS secrets to use for this route.
+	// References TLSSecret CRs by name.
+	TLSSecretRefs []string `json:"tlssecret_refs,omitempty"`
+
 	// FilterChainMatch defines when this route's filter chain is selected.
 	// This is dynamically added to the listener's filter chains.
 	FilterChainMatch *lds.FilterChainMatch `json:"filter_chain_match,omitempty"`
@@ -54,6 +58,11 @@ func (in *Route) DeepCopyInto(out *Route) {
 	*out = *in
 	if in.ListenerRefs != nil {
 		in, out := &in.ListenerRefs, &out.ListenerRefs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.TLSSecretRefs != nil {
+		in, out := &in.TLSSecretRefs, &out.TLSSecretRefs
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}


### PR DESCRIPTION
## Title
Support multiple TLS certificates (SDS) per Route via tlssecret_refs

## Summary
Routes could only attach a single downstream TLS certificate because LDS built exactly one TlsCertificateSdsSecretConfigs entry from spec.tlssecret_ref. This change wires spec.tlssecret_refs (and merges it with the existing single ref) so one route’s filter chain can reference multiple TLSSecret CRs, matching Envoy’s multi-certificate downstream TLS configuration.

## Motivation
Use cases such as multiple cert chains on one listener/SNI surface, or migrating certs, need more than one SDS secret on the same filter chain. The API surface was incomplete without actually populating Envoy from a list of secret names.

## Behavior and compatibility

- Backward compatible: Existing manifests using only tlssecret_ref behave as before (one SDS config).
- Combined use: tlssecret_ref and tlssecret_refs may be used together; the single ref is first, then list entries, with duplicates collapsed.
- Semantics: Multiple entries map to Envoy tls_certificate_sds_secret_configs on the same filter chain (multiple downstream TLS identities/cert chains for that chain).

## Notes for reviewers
Regenerating CRDs with make manifests should keep tlssecret_refs in sync with route.Route; this PR updates the checked-in base CRD so applies work without an extra generate step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routes can reference multiple TLS secrets via a new spec.tlssecret_refs field while remaining compatible with spec.tlssecret_ref.

* **Behavior**
  * If both are set, the single-field reference is applied first, then the list; names are trimmed, empty entries skipped, and duplicates removed (first-seen retained).

* **Tests**
  * Added unit tests for extraction, ordering, trimming, and deduplication.

* **Documentation**
  * Docs updated to describe multi-secret usage, precedence, and requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->